### PR TITLE
Add Windows/Mac compatibility, implement the UBX-RXM-RAWX message, fix timeout bug.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,7 @@ setup(
     author='SparkFun Electronics',
     author_email='info@sparkfun.com',
 
-    install_requires=[
-    ],
+    install_requires=["pyserial", ],
 
     # Choose your license
     license='MIT',

--- a/ublox_gps/core.py
+++ b/ublox_gps/core.py
@@ -4,7 +4,7 @@
 import struct
 import time
 from collections import namedtuple
-from serial import SerialExceptions
+from serial import SerialException
 from typing import List, Iterator, Union
 
 from serial.serialutil import SerialException

--- a/ublox_gps/core.py
+++ b/ublox_gps/core.py
@@ -2,8 +2,12 @@
 """The core structure definitions"""
 
 import struct
+import time
 from collections import namedtuple
+from serial import SerialExceptions
 from typing import List, Iterator, Union
+
+from serial.serialutil import SerialException
 
 __all__ = ['PadByte', 'Field', 'Flag', 'BitField', 'RepeatedBlock', 'Message', 'Cls', 'Parser', ]
 
@@ -435,6 +439,15 @@ class Parser:
         """
         term_len = len(terminator)
         line = bytearray()
+
+        def check_timeout(start_time) -> bool:
+            """Check to see if the timeout has been reached."""
+            if not hasattr(stream, "timeout"):
+                return False
+            
+            return (time.time() - start_time) > stream.timeout
+
+        _read_start_time = time.time()
         while True:
             c = stream.read(1)
             if c:
@@ -443,6 +456,10 @@ class Parser:
                     break
                 if size is not None and len(line) >= size:
                     break
+            elif check_timeout(_read_start_time):
+                raise SerialException(
+                    "Failed to find terminator before timeout."
+                )
             else:
                 break
 

--- a/ublox_gps/sparkfun_predefines.py
+++ b/ublox_gps/sparkfun_predefines.py
@@ -3,7 +3,7 @@
 from . import core
 
 __all__ = ['ACK_CLS', 'CFG_CLS', 'ESF_CLS', 'INF_CLS', 'MGA_CLS', 'MON_CLS',
-           'NAV_CLS', 'TIM_CLS', ]
+           'NAV_CLS', 'TIM_CLS', 'RXM_CLS', ]
 
 ACK_CLS = core.Cls(0x05, 'ACK', [
     core.Message(0x01, 'ACK', [
@@ -1127,6 +1127,51 @@ TIM_CLS = core.Cls(0x0D, 'TIM', [
         core.Field('wno', 'U2'),
         core.BitField('flags', 'X1', [
             core.Flag('src', 0, 3)
+        ]),
+    ]),
+])
+
+# From the u-blox M8 protocol spec
+# https://www.u-blox.com/sites/default/files/products/documents/u-blox8-M8_ReceiverDescrProtSpec_%28UBX-13003221%29.pdf
+RXM_CLS = core.Cls(0x02, "RXM", [  # 32.18 UBX-RXM (0x02)
+    core.Message(0x15, "RAWX", [  # 32.18.4 UBX-RXM-RAWX (0x02 0x15)
+        core.Field("rcvTow", "R8"),
+        core.Field("week", "U2"),
+        core.Field("leapS", "I1"),
+        core.Field("numMeas", "U1"),
+        core.BitField("recStat", "X1", [
+            core.Flag("leapSec", 0, 1),
+            core.Flag("clkReset", 1, 2),
+        ]),
+        core.Field("version", "U1"),
+        core.Field("reserved1a", "U1"),  # Try U2?
+        core.Field("reserved1b", "U1"),
+        core.RepeatedBlock("RB", [
+            core.Field("prMeas", "R8"),
+            core.Field("cpMeas", "R8"),
+            core.Field("doMeas", "R4"),
+            core.Field("gnssId", "U1"),
+            core.Field("svId", "U1"),
+            core.Field("sigId", "U1"),
+            core.Field("freqId", "U1"),
+            core.Field("locktime", "U2"),
+            core.Field("cno", "U1"),
+            core.BitField("prStdev", "X1", [
+                core.Flag("prStd", 0, 4),
+            ]),
+            core.BitField("cpStdev", "X1", [
+                core.Flag("cpStd", 0, 4),
+            ]),
+            core.BitField("doStdev", "X1", [
+                core.Flag("doStd", 0, 4),
+            ]),
+            core.BitField("trkStat", "X1", [
+                core.Flag("prValid", 0, 1),
+                core.Flag("coValid", 1, 2),
+                core.Flag("halfCyc", 2, 3),
+                core.Flag("subHalfCyc", 3, 4),
+            ]),
+            core.Field("reserved2", "U1"),
         ]),
     ]),
 ])

--- a/ublox_gps/ublox_gps.py
+++ b/ublox_gps/ublox_gps.py
@@ -57,7 +57,7 @@ except ModuleNotFoundError as err:
 
     # If the platform is MacOS or Windows
     if sys.platform in ["darwin", "win32", ]:
-        print("spidev not available for windows")
+        print("spidev only available for linux")
         SPI_AVAILABLE = False
     else:
         raise err
@@ -375,6 +375,21 @@ class UbloxGps(object):
         parse_tool = core.Parser([sp.ESF_CLS])
         cls_name, msg_name, payload = parse_tool.receive_from(self.hard_port)
         return payload
+
+    def rawx_measurements(self):
+        """
+        Sends a poll request for the RXM class with the RAWX measurements and
+        parses ublox messages for the response. The payload is extracted from
+        the response which is then passed to the user.
+
+        :return: The payload of the RXM Class and RAWX Message ID
+        :rtype: namedtuple
+        """
+        self.send_message(sp.RXM_CLS, self.rxm_ms.get('RAWX'))
+        parse_tool = core.Parser([sp.RXM_CLS])
+        cls_name, msg_name, payload = parse_tool.receive_from(self.hard_port)
+        s_payload = self.scale_RXM_RAWX(payload)
+        return s_payload
 
     def port_settings(self):
         """


### PR DESCRIPTION
This pull request includes 3 distinct changes.

1. There does not appear to be a version of the `spidev` module that functions natively on Mac or Windows. I added code to bypass the SPI functionality if not on a linux system. A useful warning when this bypass is triggered. 
1. The `core.Parse._read_until()` static method will continue to read until it finds a terminator. However this method bypasses the timeout, so if the read misses the terminator, then it will continue indefinitely. I used the timeout defined by the `stream` input to act as a timeout for the read. If the timeout is reached before the terminator is found, a SerialException is raised.
1. I added the UBX-RXM-RAWX message that includes pseudorange, carrier phase, and doppler measurements.