### PR TITLE
Add function to parse covariance data

### DIFF
--- a/ublox_gps/ublox_gps.py
+++ b/ublox_gps/ublox_gps.py
@@ -208,6 +208,21 @@ class UbloxGps(object):
         s_payload = self.scale_NAV_PVT(payload)
         return s_payload
 
+    def geo_cov(self):
+        """
+        Sends a poll request for the NAV class with the COV Message ID and
+        parses ublox messages for the response. The payload is extracted from
+        the response which is then passed to the user.
+
+        :return: The payload of the NAV Class and COV Message ID
+        :rtype: namedtuple
+        """
+        self.send_message(sp.NAV_CLS, self.nav_ms.get('COV'))
+        parse_tool = core.Parser([sp.NAV_CLS])
+        cls_name, msg_name, payload = parse_tool.receive_from(self.hard_port)
+        # There is no scaling factor so we can just return the payload
+        return payload
+
     def hp_geo_coords(self):
         """
         Sends a poll request for the NAV class with the HPPOSLLH Message ID and


### PR DESCRIPTION
The covariance matrix is often required for robotic navigation applications.  This PR adds a geo_cov() function to parse the covariance matrix data.